### PR TITLE
Added the ability to comment on a map

### DIFF
--- a/inc/Waymark_Types.php
+++ b/inc/Waymark_Types.php
@@ -38,7 +38,7 @@ class Waymark_Types {
 					'items_list_navigation' => esc_html__('Maps list navigation', 'waymark'),
 					'filter_items_list' => esc_html__('Filter Map list', 'waymark'),
 				),
-				'supports' => array('title', 'author', 'revisions', 'thumbnail'),
+				'supports' => array('title', 'author', 'revisions', 'thumbnail', 'comments'),
 				'hierarchical' => false,
 				'public' => true,
 				'show_ui' => true,


### PR DESCRIPTION
It only a small change, but i think more people could benefit from this.

I am using Waymark to display motorcycle routes on my websites. And i thought it would be nice if people could comment/discuss those routes. So since Waymaps is a custom post type, I added the default wordpress ability to comment on a map.