### PR TITLE
fixed issue where submit button not appearing

### DIFF
--- a/inc/Helpers/Waymark_Input.php
+++ b/inc/Helpers/Waymark_Input.php
@@ -73,7 +73,7 @@ class Waymark_Input {
 				$field['tip'] .= '.';
 			}
 
-			$out .= ' <a data-title="' . $field['tip'] . '';
+			$out .= ' <a data-title="' . esc_attr__($field['tip']) . '"';
 			if (array_key_exists('tip_link', $field)) {
 				$out .= ' ' . esc_attr__('Click here for more details.', 'waymark') . '" href="' . $field['tip_link'] . '" target="_blank" class="waymark-tooltip waymark-link"';
 			} else {

--- a/inc/Helpers/Waymark_Input.php
+++ b/inc/Helpers/Waymark_Input.php
@@ -73,11 +73,11 @@ class Waymark_Input {
 				$field['tip'] .= '.';
 			}
 
-			$out .= ' <a data-title="' . esc_attr__($field['tip']) . '"';
+			$out .= ' <a data-title="' . esc_attr__($field['tip']) . '';
 			if (array_key_exists('tip_link', $field)) {
-				$out .= ' ' . esc_attr__('Click here for more details.', 'waymark') . ' href="' . $field['tip_link'] . '" target="_blank" class="waymark-tooltip waymark-link"';
+				$out .= ' ' . esc_attr__('Click here for more details.', 'waymark') . '" href="' . $field['tip_link'] . '" target="_blank" class="waymark-tooltip waymark-link"';
 			} else {
-				$out .= ' href="#" onclick="return false;" class="waymark-tooltip"';
+				$out .= '" href="#" onclick="return false;" class="waymark-tooltip"';
 			}
 			$out .= '>?</a>';
 		}

--- a/inc/Helpers/Waymark_Input.php
+++ b/inc/Helpers/Waymark_Input.php
@@ -75,9 +75,9 @@ class Waymark_Input {
 
 			$out .= ' <a data-title="' . esc_attr__($field['tip']) . '"';
 			if (array_key_exists('tip_link', $field)) {
-				$out .= ' ' . esc_attr__('Click here for more details.', 'waymark') . '" href="' . $field['tip_link'] . '" target="_blank" class="waymark-tooltip waymark-link"';
+				$out .= ' ' . esc_attr__('Click here for more details.', 'waymark') . ' href="' . $field['tip_link'] . '" target="_blank" class="waymark-tooltip waymark-link"';
 			} else {
-				$out .= '" href="#" onclick="return false;" class="waymark-tooltip"';
+				$out .= ' href="#" onclick="return false;" class="waymark-tooltip"';
 			}
 			$out .= '>?</a>';
 		}


### PR DESCRIPTION
the unescaped string of the tip was leading to invalid HTML being rendered around the hint text due to `>` symbols in the string

this is a simple fix to sort that